### PR TITLE
Add tests for node 0.12 and iojs

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,10 @@ language: node_js
 
 node_js:
   - "0.10"
+  - "0.12"
+  - "iojs"
+
+sudo: false
 
 notifications:
   email: false


### PR DESCRIPTION
Because node 0.12 is cool, and iojs is somehow the future of node.
Container-based tests is slightly faster too.