### PR TITLE
Remove unused “url” module reference.

### DIFF
--- a/generate.js
+++ b/generate.js
@@ -5,8 +5,7 @@
 /*jslint node:true regexp:true */
 "use strict";
 
-var crypto = require("crypto"),
-    url = require("url"),
+var crypto = require("crypto");
 
     defaults = function (options) {
         return {


### PR DESCRIPTION
This PR removes the unused “url” module reference from `generate.js`.
